### PR TITLE
remove prefixes if any in GalleryHelper::link()

### DIFF
--- a/View/Helper/GalleryHelper.php
+++ b/View/Helper/GalleryHelper.php
@@ -28,6 +28,7 @@ class GalleryHelper extends AppHelper
         return $this->_View->Html->link(
             __('Upload pictures'),
             array(
+                $this->params['prefix'] => false,
                 'controller' => 'albums',
                 'action' => 'upload',
                 'plugin' => 'gallery',


### PR DESCRIPTION
upon linking to a new Gallery via the `Gallery.Gallery` helper remove
the current prefix (if any) so the resulting link is usable
-- otherwise it generates links like:
`admin/gallery/albums/upload/slide/1`

clearing prefix code taken from:
http://stackoverflow.com/questions/8014296/clearing-all-prefixes
